### PR TITLE
Add cumulative histogram

### DIFF
--- a/Statistics/Sample/Histogram.hs
+++ b/Statistics/Sample/Histogram.hs
@@ -30,6 +30,7 @@ import qualified Data.Vector.Generic.Mutable as GM
 -- The result consists of a pair of vectors:
 --
 -- * The lower bound of each interval.
+--
 -- * The number of samples within the interval.
 --
 -- Interval (bin) sizes are uniform, and the upper and lower bounds
@@ -50,6 +51,7 @@ histogram numBins xs = (G.generate numBins step, histogram_ numBins lo hi xs)
 -- The result consists of a pair of vectors:
 --
 -- * The lower bound of each interval.
+--
 -- * The number of samples within the interval and all previous intervals.
 --
 -- Interval (bin) sizes are uniform, and the upper and lower bounds


### PR DESCRIPTION
Hi Bryan,

I recently needed to generate cumulative histograms and thought it might be nice to have two convenience functions in "statistics" for this.

To that end, I've added two functions

   cumulativeHistogram (corresponding to "histogram")
   cumulativeHistogram_ (corresponding to "histogram_")

Hopefully, they can be added.

(I also fixed a little formatting issue with the haddock while I was at it.)
