### PR TITLE
Fixed error in standard log density

### DIFF
--- a/Statistics/Distribution/Normal.hs
+++ b/Statistics/Distribution/Normal.hs
@@ -76,7 +76,7 @@ instance D.ContGen NormalDistribution where
 standard :: NormalDistribution
 standard = ND { mean       = 0.0
               , stdDev     = 1.0
-              , ndPdfDenom = m_sqrt_2_pi
+              , ndPdfDenom = log m_sqrt_2_pi
               , ndCdfDenom = m_sqrt_2
               }
 


### PR DESCRIPTION
The standard distribution had an error where the log density was not the same as the log density created 'normDistr 0.0 1.0'. The standard distribution constructor was wrong.
