### PR TITLE
Update tests to work with `QuickCheck-2.7`

### DIFF
--- a/tests/Tests/Transform.hs
+++ b/tests/Tests/Transform.hs
@@ -14,7 +14,7 @@ import Statistics.Function (within)
 import Statistics.Transform (CD, dct, fft, idct, ifft)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.QuickCheck (Positive(..), Arbitrary(..), Gen, choose, vectorOf, printTestCase)
+import Test.QuickCheck (Positive(..), Arbitrary(..), Gen, choose, vectorOf, counterexample)
 import Test.QuickCheck.Property (Property(..))
 import Tests.Helpers (testAssertion)
 import Text.Printf (printf)
@@ -91,12 +91,12 @@ t_fftInverse roundtrip = MkProperty $ do
       nd = vectorNorm d
       nx = vectorNorm x
   unProperty
-     $ printTestCase "Original vector"
-     $ printTestCase (show x )
-     $ printTestCase "Transformed one"
-     $ printTestCase (show x')
-     $ printTestCase (printf "Length = %i" n)
-     $ printTestCase (printf "|x - x'| / |x| = %.6g" (nd / nx))
+     $ counterexample "Original vector"
+     $ counterexample (show x )
+     $ counterexample "Transformed one"
+     $ counterexample (show x')
+     $ counterexample (printf "Length = %i" n)
+     $ counterexample (printf "|x - x'| / |x| = %.6g" (nd / nx))
      $ nd <= 3e-14 * nx
 
 -- Test discrete cosine transform


### PR DESCRIPTION
In `2.7` `Property` is a separate type.
