### PR TITLE
Fixes a "continous" typo. However, remains backwards compatible via "…

### DIFF
--- a/Statistics/Distribution.hs
+++ b/Statistics/Distribution.hs
@@ -26,6 +26,7 @@ module Statistics.Distribution
       -- ** Random number generation
     , ContGen(..)
     , DiscreteGen(..)
+    , genContinuous
     , genContinous
       -- * Helper functions
     , findRoot
@@ -42,7 +43,7 @@ import qualified Data.Vector.Unboxed as U
 
 
 -- | Type class common to all distributions. Only c.d.f. could be
--- defined for both discrete and continous distributions.
+-- defined for both discrete and continuous distributions.
 class Distribution d where
     -- | Cumulative distribution function.  The probability that a
     -- random variable /X/ is less or equal than /x/,
@@ -159,12 +160,16 @@ class Distribution d => ContGen d where
 class (DiscreteDistr d, ContGen d) => DiscreteGen d where
   genDiscreteVar :: PrimMonad m => d -> Gen (PrimState m) -> m Int
 
--- | Generate variates from continous distribution using inverse
+-- | Generate variates from continuous distribution using inverse
 --   transform rule.
-genContinous :: (ContDistr d, PrimMonad m) => d -> Gen (PrimState m) -> m Double
-genContinous d gen = do
+genContinuous :: (ContDistr d, PrimMonad m) => d -> Gen (PrimState m) -> m Double
+genContinuous d gen = do
   x <- uniform gen
   return $! quantile d x
+
+-- | Backwards compatibility with genContinuous.
+genContinous :: (ContDistr d, PrimMonad m) => d -> Gen (PrimState m) -> m Double
+genContinous = genContinuous
 
 data P = P {-# UNPACK #-} !Double {-# UNPACK #-} !Double
 

--- a/Statistics/Distribution/Beta.hs
+++ b/Statistics/Distribution/Beta.hs
@@ -109,4 +109,4 @@ instance D.ContDistr BetaDistribution where
         error $ "Statistics.Distribution.Gamma.quantile: p must be in [0,1] range. Got: "++show p
 
 instance D.ContGen BetaDistribution where
-  genContVar = D.genContinous
+  genContVar = D.genContinuous

--- a/Statistics/Distribution/CauchyLorentz.hs
+++ b/Statistics/Distribution/CauchyLorentz.hs
@@ -76,7 +76,7 @@ instance D.ContDistr CauchyDistribution where
       error $ "Statistics.Distribution.CauchyLorentz..quantile: p must be in [0,1] range. Got: "++show p
 
 instance D.ContGen CauchyDistribution where
-  genContVar = D.genContinous
+  genContVar = D.genContinuous
 
 instance D.Entropy CauchyDistribution where
   entropy (CD _ s) = log s + log (4*pi)

--- a/Statistics/Distribution/FDistribution.hs
+++ b/Statistics/Distribution/FDistribution.hs
@@ -106,4 +106,4 @@ instance D.MaybeEntropy FDistribution where
   maybeEntropy = Just . D.entropy
 
 instance D.ContGen FDistribution where
-  genContVar = D.genContinous
+  genContVar = D.genContinuous

--- a/Statistics/Distribution/Laplace.hs
+++ b/Statistics/Distribution/Laplace.hs
@@ -82,7 +82,7 @@ instance D.MaybeEntropy LaplaceDistribution where
   maybeEntropy = Just . D.entropy
 
 instance D.ContGen LaplaceDistribution where
-  genContVar = D.genContinous
+  genContVar = D.genContinuous
 
 cumulative :: LaplaceDistribution -> Double -> Double
 cumulative (LD l s) x

--- a/Statistics/Distribution/StudentT.hs
+++ b/Statistics/Distribution/StudentT.hs
@@ -90,7 +90,7 @@ instance D.MaybeEntropy StudentT where
   maybeEntropy = Just . D.entropy
 
 instance D.ContGen StudentT where
-  genContVar = D.genContinous
+  genContVar = D.genContinuous
 
 -- | Create an unstandardized Student-t distribution.
 studentTUnstandardized :: Double -- ^ Number of degrees of freedom

--- a/Statistics/Test/KolmogorovSmirnov.hs
+++ b/Statistics/Test/KolmogorovSmirnov.hs
@@ -7,10 +7,10 @@
 -- Stability   : experimental
 -- Portability : portable
 --
--- Kolmogov-Smirnov tests are non-parametric tests for assesing
+-- Kolmogov-Smirnov tests are non-parametric tests for assessing
 -- whether given sample could be described by distribution or whether
 -- two samples have the same distribution. It's only applicable to
--- continous distributions.
+-- continuous distributions.
 module Statistics.Test.KolmogorovSmirnov (
     -- * Kolmogorov-Smirnov test
     kolmogorovSmirnovTest

--- a/tests/Tests/Distribution.hs
+++ b/tests/Tests/Distribution.hs
@@ -63,7 +63,7 @@ tests = testGroup "Tests for all distributions"
 -- Tests
 ----------------------------------------------------------------
 
--- Tests for continous distribution
+-- Tests for continuous distribution
 contDistrTests :: (Param d, ContDistr d, QC.Arbitrary d, Typeable d, Show d, Binary d, Eq d) => T d -> Test
 contDistrTests t = testGroup ("Tests for: " ++ typeName t) $
   cdfTests t ++


### PR DESCRIPTION
…genContinous" being assigned to the new "genContinuous" function.

Hi Bos,

Just seeing if you want a PR like this. There are several typos of "continous" and "Continous". I fixed those. This would break code because of the "genContinous" function, however, I left it there and assigned it to "genContinuous".

Thanks!