### PR TITLE
complCumulative documentation typo

### DIFF
--- a/Statistics/Distribution.hs
+++ b/Statistics/Distribution.hs
@@ -57,7 +57,7 @@ class Distribution d where
     --
     -- > complCumulative d x = 1 - cumulative d x
     --
-    -- It's useful when one is interested in P(/X/</x/) and
+    -- It's useful when one is interested in P(/X/>/x/) and
     -- expression on the right side begin to lose precision. This
     -- function have default implementation but implementors are
     -- encouraged to provide more precise implementation.


### PR DESCRIPTION
Simple change from `<` to `>` in documentation.