### PR TITLE
add stictness to vector updating in histogram_ to avoid space leak

### DIFF
--- a/Statistics/Sample/Histogram.hs
+++ b/Statistics/Sample/Histogram.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, BangPatterns #-}
 
 -- |
 -- Module    : Statistics.Sample.Histogram
@@ -71,8 +71,9 @@ histogram_ numBins lo hi xs0 = G.create (GM.replicate numBins 0 >>= bin xs0)
             | otherwise = do
          let x = xs `G.unsafeIndex` i
              b = truncate $ (x - lo) / d
-         GM.write bins b . (+1) =<< GM.read bins b
+         write' bins b . (+1) =<< GM.read bins b
          go (i+1)
+       write' bins b !e = GM.write bins b e
        len = G.length xs
        d = ((hi - lo) * (1 + realToFrac m_epsilon)) / fromIntegral numBins
 {-# INLINE histogram_ #-}


### PR DESCRIPTION
When using the Kernel Density Estimation algorithm, we detected a space leak that causes a stack overflow for large inputs. After some profiling, this was discovered to be due to a lack of strictness in the histogram_ function when it updates an element in a vector.
This change simply uses a bang pattern to introduce strictness in that function as necessary to remove the space leak, and enable us to run the Kernel Density Estimation functions in constant space.