### PR TITLE
Restore compatibility down to ghc-7.4.2

### DIFF
--- a/Statistics/Internal.hs
+++ b/Statistics/Internal.hs
@@ -25,6 +25,7 @@ module Statistics.Internal (
 import Control.Applicative
 import Control.Monad
 import Text.Read
+import Data.Orphans ()
 
 
 

--- a/Statistics/Resampling.hs
+++ b/Statistics/Resampling.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -37,7 +38,7 @@ module Statistics.Resampling
 import Data.Aeson (FromJSON, ToJSON)
 import Control.Applicative
 import Control.Concurrent (forkIO, newChan, readChan, writeChan)
-import Control.Monad (forM_, forM, replicateM, replicateM_)
+import Control.Monad (forM_, forM, replicateM, replicateM_, liftM2)
 import Control.Monad.Primitive (PrimMonad(..))
 import Data.Binary (Binary(..))
 import Data.Data (Data, Typeable)
@@ -82,9 +83,15 @@ data Bootstrap v a = Bootstrap
   { fullSample :: !a
   , resamples  :: v a
   }
-  deriving (Eq, Read, Show, Typeable, Data, Generic, Functor, T.Foldable, T.Traversable)
+  deriving (Eq, Read, Show , Generic, Functor, T.Foldable, T.Traversable
+#if __GLASGOW_HASKELL >= 708
+           , Typeable, Data
+#endif
+           )
 
-instance (Binary a,   Binary   (v a)) => Binary   (Bootstrap v a)
+instance (Binary a,   Binary   (v a)) => Binary   (Bootstrap v a) where
+  get = liftM2 Bootstrap get get
+  put (Bootstrap fs rs) = put fs >> put rs
 instance (FromJSON a, FromJSON (v a)) => FromJSON (Bootstrap v a)
 instance (ToJSON a,   ToJSON   (v a)) => ToJSON   (Bootstrap v a)
 

--- a/statistics.cabal
+++ b/statistics.cabal
@@ -103,6 +103,7 @@ library
   build-depends:
     aeson >= 0.6.0.0,
     base >= 4.4 && < 5,
+    base-orphans >= 0.6 && <0.7,
     binary >= 0.5.1.0,
     deepseq >= 1.1.0.2,
     erf,

--- a/tests/Tests/Serialization.hs
+++ b/tests/Tests/Serialization.hs
@@ -39,8 +39,8 @@ tests = testGroup "Test for data serialization"
   , serializationTests (T :: T (PValue Double))
   , serializationTests (T :: T (NormalErr Double))
   , serializationTests (T :: T (ConfInt   Double))
-  , serializationTests (T :: T (Estimate NormalErr Double))
-  , serializationTests (T :: T (Estimate ConfInt   Double))
+  , serializationTests' "T (Estimate NormalErr Double)" (T :: T (Estimate NormalErr Double))
+  , serializationTests' "T (Estimate ConfInt Double)" (T :: T (Estimate ConfInt   Double))
   , serializationTests (T :: T (LowerLimit Double))
   , serializationTests (T :: T (UpperLimit Double))
     -- Distributions
@@ -66,11 +66,19 @@ tests = testGroup "Test for data serialization"
 serializationTests
   :: (Eq a, Typeable a, Binary a, Show a, Read a, ToJSON a, FromJSON a, Arbitrary a)
   => T a -> Test
-serializationTests t = testGroup ("Tests for: " ++ typeName t)
+serializationTests t = serializationTests' (typeName t) t
+
+-- Not all types are Typeable, unfortunately
+serializationTests'
+  :: (Eq a, Binary a, Show a, Read a, ToJSON a, FromJSON a, Arbitrary a)
+  => String -> T a -> Test
+serializationTests' name t = testGroup ("Tests for: " ++ name)
   [ testProperty "show/read" (p_showRead t)
   , testProperty "binary"    (p_binary   t)
   , testProperty "aeson"     (p_aeson    t)
   ]
+
+
 
 p_binary :: (Eq a, Binary a) => T a -> a -> Bool
 p_binary _ a = a == (decode . encode) a


### PR DESCRIPTION
Fixes #119.

I noted that there are 3 tests which fail *often*:
- BinomialDistribution: Discrete CDF is OK:
- StudentT: Quantile is CDF inverse:
- BetaDistribution: Quantile is CDF inverse

I had to write `Binary` instance by hand, as old `binary` doesn't have `Generics` support.