### PR TITLE
Fix typos in comments

### DIFF
--- a/Statistics/Correlation/Kendall.hs
+++ b/Statistics/Correlation/Kendall.hs
@@ -5,7 +5,7 @@
 -- Fast O(NlogN) implementation of
 -- <http://en.wikipedia.org/wiki/Kendall_tau_rank_correlation_coefficient Kendall's tau>.
 --
--- This module implementes Kendall's tau form b which allows ties in the data.
+-- This module implements Kendall's tau form b which allows ties in the data.
 -- This is the same formula used by other statistical packages, e.g., R, matlab.
 --
 -- > \tau = \frac{n_c - n_d}{\sqrt{(n_0 - n_1)(n_0 - n_2)}}

--- a/Statistics/Distribution.hs
+++ b/Statistics/Distribution.hs
@@ -57,7 +57,7 @@ class Distribution d where
     -- > cumulative d -∞ = 0
     cumulative :: d -> Double -> Double
 
-    -- | One's complement of cumulative distibution:
+    -- | One's complement of cumulative distribution:
     --
     -- > complCumulative d x = 1 - cumulative d x
     --
@@ -79,7 +79,7 @@ class Distribution  d => DiscreteDistr d where
     logProbability d = log . probability d
 
 
--- | Continuous probability distributuion.
+-- | Continuous probability distribution.
 --
 --   Minimal complete definition is 'quantile' and either 'density' or
 --   'logDensity'.
@@ -111,7 +111,7 @@ class Distribution d => ContDistr d where
 class Distribution d => MaybeMean d where
     maybeMean :: d -> Maybe Double
 
--- | Type class for distributions with mean. If distribution have
+-- | Type class for distributions with mean. If a distribution has
 --   finite mean for all valid values of parameters it should be
 --   instance of this type class.
 class MaybeMean d => Mean d where
@@ -130,7 +130,7 @@ class MaybeMean d => MaybeVariance d where
     maybeStdDev   :: d -> Maybe Double
     maybeStdDev = fmap sqrt . maybeVariance
 
--- | Type class for distributions with variance. If distibution have
+-- | Type class for distributions with variance. If distribution have
 --   finite variance for all valid parameter values it should be
 --   instance of this type class.
 --
@@ -228,6 +228,6 @@ findRoot d prob = loop 0 1
 -- | Sum probabilities in inclusive interval.
 sumProbabilities :: DiscreteDistr d => d -> Int -> Int -> Double
 sumProbabilities d low hi =
-  -- Return value is forced to be less than 1 to guard againist roundoff errors.
+  -- Return value is forced to be less than 1 to guard against roundoff errors.
   -- ATTENTION! this check should be removed for testing or it could mask bugs.
   min 1 . sum . U.map (probability d) $ U.enumFromTo low hi

--- a/Statistics/Distribution/CauchyLorentz.hs
+++ b/Statistics/Distribution/CauchyLorentz.hs
@@ -88,7 +88,7 @@ errMsg _ s
   = "Statistics.Distribution.CauchyLorentz.cauchyDistribution: FWHM must be positive. Got "
   ++ show s
 
--- | Standard Cauchy distribution. It's centered at 0 and and have 1 FWHM
+-- | Standard Cauchy distribution. It's centered at 0 and have 1 FWHM
 standardCauchy :: CauchyDistribution
 standardCauchy = CD 0 1
 

--- a/Statistics/Distribution/DiscreteUniform.hs
+++ b/Statistics/Distribution/DiscreteUniform.hs
@@ -13,7 +13,7 @@
 -- inclusive interval {1, ..., n}. This is parametrized with n only,
 -- where p_1, ..., p_n = 1/n. ('discreteUniform').
 --
--- The second parametrizaton is the uniform distribution on {a, ..., b} with
+-- The second parametrization is the uniform distribution on {a, ..., b} with
 -- probabilities p_a, ..., p_b = 1/(a-b+1). This is parametrized with
 -- /a/ and /b/. ('discreteUniformAB')
 

--- a/Statistics/Distribution/Exponential.hs
+++ b/Statistics/Distribution/Exponential.hs
@@ -10,7 +10,7 @@
 -- Stability   : experimental
 -- Portability : portable
 --
--- The exponential distribution.  This is the continunous probability
+-- The exponential distribution.  This is the continuous probability
 -- distribution of the times between events in a poisson process, in
 -- which events occur continuously and independently at a constant
 -- average rate.

--- a/Statistics/Distribution/Uniform.hs
+++ b/Statistics/Distribution/Uniform.hs
@@ -69,7 +69,7 @@ uniformDistrE a b
   | b < a     = Just $ UniformDistribution b a
   | a < b     = Just $ UniformDistribution a b
   | otherwise = Nothing
--- NOTE: failure is in default branch to guard againist NaNs.
+-- NOTE: failure is in default branch to guard against NaNs.
 
 errMsg :: String
 errMsg = "Statistics.Distribution.Uniform.uniform: wrong parameters"

--- a/Statistics/Math/RootFinding.hs
+++ b/Statistics/Math/RootFinding.hs
@@ -113,7 +113,7 @@ ridders tol (lo,hi) f
     go !a !fa !b !fb !i
         -- Root is bracketed within 1 ulp. No improvement could be made
         | within 1 a b       = Root a
-        -- Root is found. Check that f(m) == 0 is nessesary to ensure
+        -- Root is found. Check that f(m) == 0 is necessary to ensure
         -- that root is never passed to 'go'
         | fm == 0            = Root m
         | fn == 0            = Root n

--- a/Statistics/Sample.hs
+++ b/Statistics/Sample.hs
@@ -66,7 +66,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Unboxed as U
 
--- Operator ^ will be overriden
+-- Operator ^ will be overridden
 import Prelude hiding ((^), sum)
 
 -- | /O(n)/ Range. The difference between the largest and smallest

--- a/Statistics/Test/KolmogorovSmirnov.hs
+++ b/Statistics/Test/KolmogorovSmirnov.hs
@@ -61,7 +61,7 @@ kolmogorovSmirnovTest d
   = kolmogorovSmirnovTestCdf (cumulative d)
 
 
--- | Variant of 'kolmogorovSmirnovTest' which uses CFD in form of
+-- | Variant of 'kolmogorovSmirnovTest' which uses CDF in form of
 --   function.
 kolmogorovSmirnovTestCdf :: (G.Vector v Double)
                          => (Double -> Double) -- ^ CDF of distribution

--- a/Statistics/Test/KruskalWallis.hs
+++ b/Statistics/Test/KruskalWallis.hs
@@ -78,7 +78,7 @@ kruskalWallis samples = (nTot - 1) * numerator / denominator
 -- significance. For additional information check 'kruskalWallis'. This is just
 -- a helper function.
 --
--- It uses /Chi-Squared/ distribution for aproximation as long as the sizes are
+-- It uses /Chi-Squared/ distribution for approximation as long as the sizes are
 -- larger than 5. Otherwise the test returns 'Nothing'.
 kruskalWallisTest :: (Ord a, U.Unbox a) => [U.Vector a] -> Maybe (Test ())
 kruskalWallisTest []      = Nothing

--- a/Statistics/Test/MannWhitneyU.hs
+++ b/Statistics/Test/MannWhitneyU.hs
@@ -8,7 +8,7 @@
 -- Portability : portable
 --
 -- Mann-Whitney U test (also know as Mann-Whitney-Wilcoxon and
--- Wilcoxon rank sum test) is a non-parametric test for assesing
+-- Wilcoxon rank sum test) is a non-parametric test for assessing
 -- whether two samples of independent observations have different
 -- mean.
 module Statistics.Test.MannWhitneyU (
@@ -109,7 +109,7 @@ mannWhitneyUCriticalValue
   -> Maybe Int      -- ^ The critical value (of U).
 mannWhitneyUCriticalValue (m, n) p
   | m < 1 || n < 1 = Nothing    -- Sample must be nonempty
-  | p' <= 1        = Nothing    -- p-value is too small. Null hypothesys couln't be disproved
+  | p' <= 1        = Nothing    -- p-value is too small. Null hypothesis couldn't be disproved
   | otherwise      = findIndex (>= p')
                    $ take (m*n)
                    $ tail

--- a/Statistics/Test/StudentT.hs
+++ b/Statistics/Test/StudentT.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts, Rank2Types, ScopedTypeVariables #-}
--- | Student's T-test is for assesing whether two samples have
+-- | Student's T-test is for assessing whether two samples have
 --   different mean. This module contain several variations of
 --   T-test. It's a parametric tests and assumes that samples are
 --   normally distributed.

--- a/Statistics/Test/Types.hs
+++ b/Statistics/Test/Types.hs
@@ -87,7 +87,7 @@ instance FromJSON PositionTest
 instance ToJSON   PositionTest
 instance NFData   PositionTest
 
--- | significant if parameter is 'True', not significant otherwiser
+-- | significant if parameter is 'True', not significant otherwise
 significant :: Bool -> TestResult
 significant True  = Significant
 significant False = NotSignificant

--- a/Statistics/Test/WilcoxonT.hs
+++ b/Statistics/Test/WilcoxonT.hs
@@ -37,7 +37,7 @@ module Statistics.Test.WilcoxonT (
 -- function in this module to get a meaningful result.
 -- ranks of the differences where the first parameter is higher) whereas T- is
 -- the sum of negative ranks (the ranks of the differences where the second parameter is higher).
--- to the the length of the shorter sample.
+-- to the length of the shorter sample.
 
 import Control.Applicative ((<$>))
 import Data.Function (on)
@@ -207,7 +207,7 @@ normalApprox ni
 
 -- | The Wilcoxon matched-pairs signed-rank test. The samples are
 -- zipped together: if one is longer than the other, both are
--- truncated to the the length of the shorter sample.
+-- truncated to the length of the shorter sample.
 --
 -- For one-tailed test it tests whether first sample is significantly
 -- greater than the second. For two-tailed it checks whether they


### PR DESCRIPTION
There were a couple small typos in the documentation, this should fix them.