### PR TITLE
Add async-2.2.2 as an extra-dep to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,5 @@ packages:
  - dense-linear-algebra/
 
 extra-deps:
+ - async-2.2.2
  - math-functions-0.3.0.2


### PR DESCRIPTION
`async-2.2.2` isn't resolvable with `lts-12.12` (but rather, `async-2.2.1` is). 

To remedy this, I've added `async-2.2.2` to the `extra-deps` in `stack.yaml`.