### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,22 +18,22 @@ jobs:
       matrix:
         include:
           # Linux
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "8.4.4"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "8.6.5"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "8.8.4"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "8.10.7" }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.0.2"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.2.8"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.4.8"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.6.7"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.8.4"  }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.10.2" }
-          - { cabal: "3.14", os: ubuntu-latest,  ghc: "9.12.2" }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "8.4.4"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "8.6.5"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "8.8.4"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "8.10.7" }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.0.2"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.2.8"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.4.8"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.6.7"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.8.4"  }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.10.2" }
+          - { cabal: "3.16", os: ubuntu-latest,  ghc: "9.12.2" }
           # Macos
-          - { cabal: "3.14", os: macos-latest,  ghc: "9.6.7"  }
-          - { cabal: "3.14", os: macos-latest,  ghc: "9.8.4"  }
-          - { cabal: "3.14", os: macos-latest,  ghc: "9.10.2" }
-          - { cabal: "3.14", os: macos-latest,  ghc: "9.12.2" }
+          - { cabal: "3.16", os: macos-latest,  ghc: "9.6.7"  }
+          - { cabal: "3.16", os: macos-latest,  ghc: "9.8.4"  }
+          - { cabal: "3.16", os: macos-latest,  ghc: "9.10.2" }
+          - { cabal: "3.16", os: macos-latest,  ghc: "9.12.2" }
       fail-fast: false
 
     steps:
@@ -51,7 +51,7 @@ jobs:
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-        key: ${{ runner.os }}-${{ matrix.ghc }}---CACHE_V3
+        key: ${{ runner.os }}-${{ matrix.ghc }}---CACHE_V4
     # ----------------
     - name: "Install PAPI"
       run: |
@@ -92,4 +92,5 @@ jobs:
     # ----------------
     - name: Bench
       run: |
+        cd unpacked/statistics-*
         cabal bench all


### PR DESCRIPTION
 - Use cabal 3.16
 - GHC 9.14 will be added once aeson builds with it.
 - Bust cache. There's some common problem with GHC 9.0 & 9.2. Real reason is not known bu clearing cache helps